### PR TITLE
Fix build script

### DIFF
--- a/.changeset/nine-yaks-relax.md
+++ b/.changeset/nine-yaks-relax.md
@@ -1,0 +1,14 @@
+---
+'@navita/css': patch
+'@navita/adapter': patch
+'@navita/core': patch
+'@navita/engine': patch
+'@navita/jest': patch
+'@navita/next-plugin': patch
+'@navita/swc': patch
+'@navita/types': patch
+'@navita/vite-plugin': patch
+'@navita/webpack-plugin': patch
+---
+
+fix build script so tree shaking actually works when consuming packages

--- a/packages/css/src/classList.ts
+++ b/packages/css/src/classList.ts
@@ -1,5 +1,0 @@
-export class ClassList extends String {
-  constructor(str: string, public classList: { [key: string]: string[] }) {
-    super(str);
-  }
-}

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -5,7 +5,6 @@ export { keyframes } from './keyframes';
 export { fontFace } from './fontFace';
 export { createTheme, createGlobalTheme, createGlobalThemeContract, createThemeContract } from './theme';
 export { assignVars, createVar, fallbackVar } from './vars';
-export { ClassList } from './classList';
 const source = '@navita/css';
 export const importMap = [
   {

--- a/scripts/build/src/transpile.ts
+++ b/scripts/build/src/transpile.ts
@@ -20,6 +20,7 @@ export async function transpile({ input, format, extension, outDir, packagePath,
     output: [{
       dir: outDir,
       format,
+      preserveModules: true,
       entryFileNames: `[name]${extension}`,
       chunkFileNames: `[name]${extension}`,
     }],


### PR DESCRIPTION
Rollup started to include sideEffects in the builds. Turns out we needed `preserveModules: true`.