### PR TITLE
Relax types

### DIFF
--- a/.changeset/fluffy-books-fold.md
+++ b/.changeset/fluffy-books-fold.md
@@ -1,0 +1,7 @@
+---
+'@navita/engine': patch
+'@navita/types': patch
+'@navita/css': patch
+---
+
+Relax TypeScript types a touch

--- a/packages/css/src/vars.ts
+++ b/packages/css/src/vars.ts
@@ -4,8 +4,8 @@ import cssesc from 'cssesc';
 import { walkObject } from "./helpers/walkObject";
 import { validateContract } from "./validateContract";
 
-export function createVar(name: string) {
-  return `--${cssesc(!name ? generateIdentifier(undefined) : name, { isIdentifier: true })}`;
+export function createVar<T extends string>(name?: T): `--${T}` {
+  return `--${cssesc(!name ? generateIdentifier(undefined) : name, { isIdentifier: true }) as T}`;
 }
 
 export function fallbackVar(

--- a/packages/engine/src/helpers/normalizeCSSVarsValue.ts
+++ b/packages/engine/src/helpers/normalizeCSSVarsValue.ts
@@ -1,0 +1,13 @@
+const cssVarRegex = /(?<!var\()(\s*)(--[a-zA-Z0-9_-]+)/g;
+
+export function normalizeCSSVarsValue(value: string) {
+  if (
+    value.startsWith('--') ||
+    value.includes(' --') ||
+    value.includes(',--')
+  ) {
+    return value.replace(cssVarRegex, "$1var($2)");
+  }
+
+  return value;
+}

--- a/packages/engine/src/processStyles.ts
+++ b/packages/engine/src/processStyles.ts
@@ -11,6 +11,7 @@ import { normalizeNestedProperty } from "./helpers/normalizeNestedProperty";
 import { pixelifyProperties } from "./helpers/pixelifyProperties";
 import { transformContentProperty } from "./helpers/transformContentProperty";
 import type { StyleBlock } from "./types";
+import { normalizeCSSVarsValue } from "./helpers/normalizeCSSVarsValue";
 
 const transformValuePropertyMap = {
   content: transformContentProperty,
@@ -94,11 +95,7 @@ export function processStyles({
 
         if (typeof value === "string") {
           newValue = value.trim().replace(/;[\n\s]*$/, "");
-        }
-
-        // Check if value starts with --, if so, wrap in var()
-        if (typeof newValue === "string" && newValue.startsWith("--")) {
-          newValue = `var(${value})`;
+          newValue = normalizeCSSVarsValue(newValue);
         }
 
         if (typeof value === "number") {

--- a/packages/engine/tests/src/helpers/normalizeCSSVarsValue.test.ts
+++ b/packages/engine/tests/src/helpers/normalizeCSSVarsValue.test.ts
@@ -1,0 +1,23 @@
+import { normalizeCSSVarsValue } from "../../../src/helpers/normalizeCSSVarsValue";
+
+describe('normalizeCSSVarsValue', () => {
+  it('should only replace css var with var() if it is not already', () => {
+    expect(normalizeCSSVarsValue('var(--my-var)')).toBe('var(--my-var)');
+    expect(normalizeCSSVarsValue('--my-var')).toBe('var(--my-var)');
+    expect(normalizeCSSVarsValue('var(--my-var) var(--my-var)')).toBe('var(--my-var) var(--my-var)');
+    expect(normalizeCSSVarsValue('var(--my-var) --my-var')).toBe('var(--my-var) var(--my-var)');
+    expect(normalizeCSSVarsValue('--my-var var(--my-var)')).toBe('var(--my-var) var(--my-var)');
+    expect(normalizeCSSVarsValue('--my-var --my-var')).toBe('var(--my-var) var(--my-var)');
+  });
+
+  it('should work with css vars in real life', () => {
+    expect(normalizeCSSVarsValue('0px 2px 0px --box-shadow-color')).toBe('0px 2px 0px var(--box-shadow-color)');
+    expect(normalizeCSSVarsValue('0px 2px 0px var(--box-shadow-color)')).toBe('0px 2px 0px var(--box-shadow-color)');
+    expect(normalizeCSSVarsValue('var(--box-shadow-color) 0px 2px 0px')).toBe('var(--box-shadow-color) 0px 2px 0px');
+  });
+
+  it('should work with fallback vars', () => {
+    expect(normalizeCSSVarsValue('var(--my-var, --this-is-wrong)')).toBe('var(--my-var, var(--this-is-wrong))');
+    expect(normalizeCSSVarsValue('var(--my-var,--this-is-wrong)')).toBe('var(--my-var,var(--this-is-wrong))');
+  });
+});

--- a/packages/engine/tests/src/processStyles.test.ts
+++ b/packages/engine/tests/src/processStyles.test.ts
@@ -474,7 +474,7 @@ describe('processStyles', () => {
     warn.mockReset();
   });
 
-  it('adds a var() wrapper to values that start with --', () => {
+  it('adds a var()-func to naked css vars', () => {
     const processStyles = createProcessStyles({
       type: "rule",
     });
@@ -482,10 +482,11 @@ describe('processStyles', () => {
     const result = processStyles({
       styles: {
         color: "--red",
+        boxShadow: "0px 2px 0px --box-shadow-color",
       },
     });
 
-    expect(result).toHaveLength(1);
+    expect(result).toHaveLength(2);
     expect(result).toEqual([
       expect.objectContaining({
         id: 1,
@@ -493,10 +494,16 @@ describe('processStyles', () => {
         value: "var(--red)",
         pseudo: '',
       }),
+      expect.objectContaining({
+        id: 2,
+        property: "box-shadow",
+        value: "0px 2px 0px var(--box-shadow-color)",
+        pseudo: '',
+      }),
     ]);
   });
 
-  it(`doesn't touch values that don't start with --`, () => {
+  it(`doesn't touch values that already have var()-func`, () => {
     const processStyles = createProcessStyles({
       type: "rule",
     });
@@ -504,15 +511,22 @@ describe('processStyles', () => {
     const result = processStyles({
       styles: {
         color: "var(--red)",
+        boxShadow: "0px 2px 0px var(--box-shadow-color)",
       },
     });
 
-    expect(result).toHaveLength(1);
+    expect(result).toHaveLength(2);
     expect(result).toEqual([
       expect.objectContaining({
         id: 1,
         property: "color",
         value: "var(--red)",
+        pseudo: '',
+      }),
+      expect.objectContaining({
+        id: 2,
+        property: "box-shadow",
+        value: "0px 2px 0px var(--box-shadow-color)",
         pseudo: '',
       }),
     ]);

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -6,6 +6,8 @@ export type ImportMap = {
   source: string;
 }[];
 
+export type RawCSSVarFunction = `--${string}`;
+
 export type CSSVarFunction =
   | `var(--${string})`
   | `var(--${string}, ${string | number})`;
@@ -59,11 +61,8 @@ export type CSSProperties = {
   [Property in keyof CSSTypeProperties]:
   | CSSTypeProperties[Property]
   | CSSVarFunction
+  | RawCSSVarFunction
 };
-
-export interface CSSKeyframes {
-  [time: string]: CSSProperties;
-}
 
 interface MediaQueries<StyleType> {
   [string: `@media${string}`]: StyleType;
@@ -94,16 +93,15 @@ export type WithQueries<StyleType> = MediaQueries<
   >;
 
 interface WithDirectDescendants<StyleType> {
-  [string: `> ${string}`]: StyleType;
+  [string: `>${string}`]: StyleType;
 }
 
-interface WithNestedSelectors<StyleType> {
-  [string: `& ${string}`]: StyleType;
+interface WithNestedSelectors<StyleRule> {
+  [string: `&${string}`]: StyleRule;
 }
 
-type WithPseudoSelectors<StyleType> = {
-  // Todo: fix this properly
-  [key in SimplePseudos | `${SimplePseudos},${SimplePseudos}` | `${SimplePseudos}, ${SimplePseudos}`]?: StyleType;
+type WithSimplePseudoSelectors<StyleType> = {
+  [key in `${SimplePseudos}${string}`]?: StyleType;
 }
 
 type WithAdvancedPseudoSelectors<StyleType> = {
@@ -113,9 +111,11 @@ type WithAdvancedPseudoSelectors<StyleType> = {
 export interface StyleRule extends
   CSSProperties,
   WithQueries<StyleRule>,
-  WithPseudoSelectors<StyleRule>,
+  WithSimplePseudoSelectors<StyleRule>,
   WithAdvancedPseudoSelectors<StyleRule>,
   WithDirectDescendants<StyleRule>,
-  WithNestedSelectors<StyleRule> {}
+  WithNestedSelectors<StyleRule> {
+  [string: `--${string}`]: string | number;
+}
 
 export type GlobalStyleRule = StyleRule;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -64,6 +64,10 @@ export type CSSProperties = {
   | RawCSSVarFunction
 };
 
+export interface CSSKeyframes {
+  [time: string]: CSSProperties;
+}
+
 interface MediaQueries<StyleType> {
   [string: `@media${string}`]: StyleType;
 }

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,4 +1,3 @@
 {
-  "extends": "../../tsconfig.json",
-  "exclude": ["dist"]
+  "extends": "../../tsconfig.json"
 }


### PR DESCRIPTION
The types for `style` was a bit too strict in some cases. This relaxes them quite a bit. It's still up to the user to write correct selectors. 

Index signatures and template literal strings are not recognised by TypeScript, so users will have to cast in cases such as:

```typescript
import { style } from '@navita/css';

const someName = 'a b c'.replaceAll(' ', '.');

const x = style({
// TypeScript will not be able to infer this as // "&${string}" even though that's the key. 
// Fix by doing "as const" (in some cases where it's able to be infered) or lie to the compiler like this
[`& ${someName}` as '& someName']: {
  background: 'hotpink',
}
});

// ^- That's a contrived example, and even though it works in Navita,
// you should try to avoid it and structure your html/css better.
// That will create a few css declarations that you are never going to be repeating, thus circumventing atomic css. 
```