### PR TITLE
Ease css var normalization

### DIFF
--- a/.changeset/serious-plants-double.md
+++ b/.changeset/serious-plants-double.md
@@ -1,0 +1,5 @@
+---
+'@navita/engine': minor
+---
+
+ease check for running normalize css vars

--- a/packages/engine/src/helpers/normalizeCSSVarsValue.ts
+++ b/packages/engine/src/helpers/normalizeCSSVarsValue.ts
@@ -1,11 +1,7 @@
 const cssVarRegex = /(?<!var\()(\s*)(--[a-zA-Z0-9_-]+)/g;
 
 export function normalizeCSSVarsValue(value: string) {
-  if (
-    value.startsWith('--') ||
-    value.includes(' --') ||
-    value.includes(',--')
-  ) {
+  if (value.includes('--')) {
     return value.replace(cssVarRegex, "$1var($2)");
   }
 

--- a/packages/engine/tests/src/helpers/normalizeCSSVarsValue.test.ts
+++ b/packages/engine/tests/src/helpers/normalizeCSSVarsValue.test.ts
@@ -20,4 +20,9 @@ describe('normalizeCSSVarsValue', () => {
     expect(normalizeCSSVarsValue('var(--my-var, --this-is-wrong)')).toBe('var(--my-var, var(--this-is-wrong))');
     expect(normalizeCSSVarsValue('var(--my-var,--this-is-wrong)')).toBe('var(--my-var,var(--this-is-wrong))');
   });
+
+  it('should cover https://github.com/eagerpatch/navita/issues/21#issue-1992454530', () => {
+    expect(normalizeCSSVarsValue('rgba(--color, 0.15)')).toBe('rgba(var(--color), 0.15)');
+    expect(normalizeCSSVarsValue('rgba(--color,0.15)')).toBe('rgba(var(--color),0.15)');
+  });
 });

--- a/packages/engine/tests/src/index.test.ts
+++ b/packages/engine/tests/src/index.test.ts
@@ -355,4 +355,17 @@ describe('Engine', () => {
       expect(engine.generateIdentifier('background')).toEqual('_b');
     });
   });
+
+  describe('issue #21', () => {
+    it('should generate correct css', () => {
+      const engine = new Engine();
+      engine.setFilePath('file1.ts');
+      engine.addStyle({
+        color: 'rgba(--color, 0.15)',
+      });
+      expect(engine.renderCssToString()).toEqual(
+        `.a1{color:rgba(var(--color), 0.15)}`,
+      );
+    });
+  });
 });


### PR DESCRIPTION
This makes the check if it needs to run the regex much looser. 

Closes https://github.com/eagerpatch/navita/issues/21